### PR TITLE
fix merge config issue

### DIFF
--- a/src/rhel_containers/conf/conf.yaml
+++ b/src/rhel_containers/conf/conf.yaml
@@ -1,5 +1,5 @@
 default:
-  RHEL_CONTAINERS:
+  rhel_containers:
     repositories:
       7: "registry.access.redhat.com/ubi7/ubi-init"
       8: "registry.access.redhat.com/ubi8/ubi-init"
@@ -16,7 +16,7 @@ default:
       base_url:
       proxy:
 qa:
-  RHEL_CONTAINERS:
+  rhel_containers:
     subscription:
       serverurl: subscription.rhsm.qa.redhat.com
       baseurl: http://cdn.redhat.com/
@@ -24,7 +24,7 @@ qa:
       base_url: qa.cloud.redhat.com/api
 
 ci:
-  RHEL_CONTAINERS:
+  rhel_containers:
     subscription:
       serverurl: subscription.rhsm.qa.redhat.com
       baseurl: http://cdn.redhat.com/
@@ -32,6 +32,6 @@ ci:
       base_url: ci.cloud.redhat.com/api
 
 stage:
-  RHEL_CONTAINERS:
+  rhel_containers:
     subscription:
       serverurl: "subscription.rhsm.stage.redhat.com"

--- a/src/rhel_containers/config.py
+++ b/src/rhel_containers/config.py
@@ -48,4 +48,4 @@ def load_config(env, extra_conf=None):
     # for iqe testing, we can pass extra_conf.
     if extra_conf:
         conf = merge(conf, extra_conf)
-    return Box(conf).RHEL_CONTAINERS
+    return Box(conf).rhel_containers


### PR DESCRIPTION
RHEL_CONTAINERS and rhel_containers variables creating two keys in config instead of one so fixed issue and using the lower case as per iqe-core settings.default.local file